### PR TITLE
Change 86SW1 type

### DIFF
--- a/hardware/XiaomiGateway.cpp
+++ b/hardware/XiaomiGateway.cpp
@@ -572,7 +572,7 @@ void XiaomiGateway::xiaomi_udp_server::handle_receive(const boost::system::error
 					}
 					else if (model == "86sw1") {
 						name = "Xiaomi Wireless Single Wall Switch";
-						type = STYPE_Selector;
+						type = STYPE_PushOn;
 					}
 					if (type != STYPE_END) {
 						std::string status = root2["status"].asString();


### PR DESCRIPTION
86SW1 only send Click

from api {"cmd":"report","model":"86sw1","sid":"112316","short_id":4343,"data":"{\"channel_0\":\"click\"}" }}

https://louiszl.gitbooks.io/lumi-gateway-local-api/content/86sw1.html

Change Type from selector to simple PushON